### PR TITLE
Fix layout width and useGoBack hook

### DIFF
--- a/src/app/(admin)/layout.tsx
+++ b/src/app/(admin)/layout.tsx
@@ -32,7 +32,7 @@ export default function AdminLayout({
         {/* Header */}
         <AppHeader />
         {/* Page Content */}
-        <div className="p-4 mx-auto max-w-(--breakpoint-2xl) md:p-6">{children}</div>
+        <div className="p-4 mx-auto max-w-[var(--breakpoint-2xl)] md:p-6">{children}</div>
       </div>
     </div>
   );

--- a/src/hooks/useGoBack.ts
+++ b/src/hooks/useGoBack.ts
@@ -1,3 +1,4 @@
+"use client";
 import { useRouter } from "next/navigation";
 
 const useGoBack = () => {


### PR DESCRIPTION
## Summary
- fix custom max width usage in admin layout
- mark useGoBack as client-only

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6876effa53708326a12c15bd90e4d08e