### PR TITLE
Add payroll advance modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "react-dnd-html5-backend": "^16.0.1",
     "react-dom": "^19.0.0",
     "react-dropzone": "^14.3.5",
+    "firebase": "^10.12.0",
     "swiper": "^11.2.0",
     "tailwind-merge": "^2.6.0"
   },

--- a/src/app/(admin)/company/page.tsx
+++ b/src/app/(admin)/company/page.tsx
@@ -1,0 +1,21 @@
+import DropzoneComponent from "@/components/form/form-elements/DropZone";
+import UsersChart from "@/components/analytics/UsersChart";
+import { Metadata } from "next";
+import React from "react";
+
+export const metadata: Metadata = {
+  title: "Empresa - Gestión de Nómina",
+  description: "Carga de empleados por CSV",
+};
+
+export default function CompanyPage() {
+  return (
+    <div className="space-y-6">
+      <h2 className="text-lg font-semibold text-gray-800 dark:text-white/90">
+        Cargar Nómina
+      </h2>
+      <DropzoneComponent />
+      <UsersChart />
+    </div>
+  );
+}

--- a/src/app/(admin)/management/page.tsx
+++ b/src/app/(admin)/management/page.tsx
@@ -1,0 +1,21 @@
+import BasicTableOne from "@/components/tables/BasicTableOne";
+import UsersChart from "@/components/analytics/UsersChart";
+import { Metadata } from "next";
+import React from "react";
+
+export const metadata: Metadata = {
+  title: "Administración",
+  description: "Gestión de usuarios y empresas",
+};
+
+export default function ManagementPage() {
+  return (
+    <div className="space-y-6">
+      <h2 className="text-lg font-semibold text-gray-800 dark:text-white/90">
+        Panel de Administración
+      </h2>
+      <BasicTableOne />
+      <UsersChart />
+    </div>
+  );
+}

--- a/src/app/(admin)/users/page.tsx
+++ b/src/app/(admin)/users/page.tsx
@@ -1,0 +1,21 @@
+import LoanSimulator from "@/components/loan/LoanSimulator";
+import UsersChart from "@/components/analytics/UsersChart";
+import { Metadata } from "next";
+import React from "react";
+
+export const metadata: Metadata = {
+  title: "Usuarios - Adelanto de Nómina",
+  description: "Simulador y perfil de usuario",
+};
+
+export default function UsersPage() {
+  return (
+    <div className="space-y-6">
+      <h2 className="text-lg font-semibold text-gray-800 dark:text-white/90">
+        Simulador de Adelanto
+      </h2>
+      <LoanSimulator />
+      <UsersChart />
+    </div>
+  );
+}

--- a/src/components/analytics/UsersChart.tsx
+++ b/src/components/analytics/UsersChart.tsx
@@ -1,0 +1,33 @@
+"use client";
+import dynamic from "next/dynamic";
+import { ApexOptions } from "apexcharts";
+import { collection, getDocs } from "firebase/firestore";
+import { useEffect, useState } from "react";
+import { db } from "@/firebase";
+
+const ReactApexChart = dynamic(() => import("react-apexcharts"), { ssr: false });
+
+export default function UsersChart() {
+  const [users, setUsers] = useState<number[]>([]);
+
+  useEffect(() => {
+    async function load() {
+      const snap = await getDocs(collection(db, "usuarios"));
+      setUsers([snap.size]);
+    }
+    load();
+  }, []);
+
+  const options: ApexOptions = {
+    chart: { id: "users" },
+    labels: ["Usuarios"],
+  };
+
+  const series = users;
+
+  return (
+    <div className="rounded-2xl border border-gray-200 bg-white p-5 dark:border-gray-800 dark:bg-white/[0.03]">
+      <ReactApexChart options={options} series={series} type="pie" height={200} />
+    </div>
+  );
+}

--- a/src/components/header/UserDropdown.tsx
+++ b/src/components/header/UserDropdown.tsx
@@ -1,6 +1,5 @@
 "use client";
 import Image from "next/image";
-import Link from "next/link";
 import React, { useState } from "react";
 import { Dropdown } from "../ui/dropdown/Dropdown";
 import { DropdownItem } from "../ui/dropdown/DropdownItem";

--- a/src/components/loan/LoanSimulator.tsx
+++ b/src/components/loan/LoanSimulator.tsx
@@ -1,0 +1,62 @@
+"use client";
+import React, { useState, useEffect } from "react";
+import Input from "@/components/form/input/InputField";
+import { useAuth } from "@/context/AuthContext";
+import { doc, getDoc } from "firebase/firestore";
+import { db } from "@/firebase";
+
+export default function LoanSimulator() {
+  const { user } = useAuth();
+  const [salary, setSalary] = useState(0);
+  const [amount, setAmount] = useState(0);
+  const [months, setMonths] = useState(1);
+  const [quota, setQuota] = useState(0);
+
+  useEffect(() => {
+    if (user) {
+      const ref = doc(db, "usuarios", user.uid);
+      getDoc(ref).then((snap) => {
+        if (snap.exists()) {
+          const data = snap.data() as { salario?: number };
+          setSalary(data.salario ?? 0);
+        }
+      });
+    }
+  }, [user]);
+
+  useEffect(() => {
+    if (amount && months) {
+      const interest = 0.02; // simple monthly interest
+      const monthly = (amount * (1 + interest * months)) / months;
+      setQuota(Math.round(monthly * 100) / 100);
+    }
+  }, [amount, months]);
+
+  return (
+    <div className="space-y-4">
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+        <Input
+          type="number"
+          placeholder="Monto"
+          onChange={(e) => setAmount(Number(e.target.value))}
+          max={(salary * 2).toString()}
+          hint={`Max: ${salary * 2}`}
+        />
+        <Input
+          type="number"
+          placeholder="Meses"
+          onChange={(e) => setMonths(Number(e.target.value))}
+          min="1"
+        />
+      </div>
+      <div className="p-4 rounded-lg bg-gray-50 dark:bg-gray-900">
+        <p className="font-medium text-gray-700 dark:text-gray-400">
+          Cuota mensual aproximada:
+        </p>
+        <p className="text-xl font-semibold text-gray-800 dark:text-white/90">
+          {quota.toLocaleString("es-CO", { style: "currency", currency: "COP" })}
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/firebase.ts
+++ b/src/firebase.ts
@@ -1,5 +1,6 @@
 import { initializeApp, getApp, getApps } from "firebase/app";
 import { getAuth } from "firebase/auth";
+import { getFirestore } from "firebase/firestore";
 
 const firebaseConfig = {
   apiKey: "AIzaSyChv1IaDTsQ9nr8qqZytRIYDoBkBjljoAY",
@@ -12,4 +13,5 @@ const firebaseConfig = {
 
 const app = getApps().length ? getApp() : initializeApp(firebaseConfig);
 export const auth = getAuth(app);
+export const db = getFirestore(app);
 export default app;


### PR DESCRIPTION
## Summary
- include firebase package
- init Firestore database
- add loan simulator component
- add KPI chart example
- create new user, company and admin pages
- fix lint warning in `UserDropdown`

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68770b6f2bb08326b1f4f57cb506cc62