### PR TITLE
Fix user profile editing and add basic Firestore table

### DIFF
--- a/src/components/tables/BasicTableOne.tsx
+++ b/src/components/tables/BasicTableOne.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import {
   Table,
   TableBody,
@@ -9,6 +9,8 @@ import {
 
 import Badge from "../ui/badge/Badge";
 import Image from "next/image";
+import { collection, getDocs } from "firebase/firestore";
+import { db } from "@/firebase";
 
 interface Order {
   id: number;
@@ -23,6 +25,13 @@ interface Order {
   };
   status: string;
   budget: string;
+}
+
+interface UserRow {
+  id: string;
+  name: string;
+  email: string;
+  role?: string;
 }
 
 // Define the table data using the interface
@@ -112,6 +121,21 @@ const tableData: Order[] = [
 ];
 
 export default function BasicTableOne() {
+  const [users, setUsers] = useState<UserRow[]>([]);
+
+  useEffect(() => {
+    async function load() {
+      const snap = await getDocs(collection(db, "users"));
+      const rows = snap.docs.map((d) => ({
+        id: d.id,
+        name: `${d.data().firstName ?? ""} ${d.data().lastName ?? ""}`.trim(),
+        email: d.data().email ?? "",
+        role: d.data().role ?? "",
+      }));
+      setUsers(rows);
+    }
+    load();
+  }, []);
   return (
     <div className="overflow-hidden rounded-xl border border-gray-200 bg-white dark:border-white/[0.05] dark:bg-white/[0.03]">
       <div className="max-w-full overflow-x-auto">
@@ -219,6 +243,40 @@ export default function BasicTableOne() {
               ))}
             </TableBody>
           </Table>
+          {users.length > 0 && (
+            <div className="mt-8">
+              <Table>
+                <TableHeader className="border-b border-gray-100 dark:border-white/[0.05]">
+                  <TableRow>
+                    <TableCell isHeader className="px-5 py-3 font-medium text-gray-500 text-start text-theme-xs dark:text-gray-400">
+                      Name
+                    </TableCell>
+                    <TableCell isHeader className="px-5 py-3 font-medium text-gray-500 text-start text-theme-xs dark:text-gray-400">
+                      Email
+                    </TableCell>
+                    <TableCell isHeader className="px-5 py-3 font-medium text-gray-500 text-start text-theme-xs dark:text-gray-400">
+                      Role
+                    </TableCell>
+                  </TableRow>
+                </TableHeader>
+                <TableBody className="divide-y divide-gray-100 dark:divide-white/[0.05]">
+                  {users.map((u) => (
+                    <TableRow key={u.id}>
+                      <TableCell className="px-5 py-3 text-start text-theme-sm text-gray-800 dark:text-white/90">
+                        {u.name}
+                      </TableCell>
+                      <TableCell className="px-5 py-3 text-start text-theme-sm text-gray-500 dark:text-gray-400">
+                        {u.email}
+                      </TableCell>
+                      <TableCell className="px-5 py-3 text-start text-theme-sm text-gray-500 dark:text-gray-400">
+                        {u.role || "-"}
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </div>
+          )}
         </div>
       </div>
     </div>

--- a/src/components/user-profile/UserInfoCard.tsx
+++ b/src/components/user-profile/UserInfoCard.tsx
@@ -6,13 +6,21 @@ import Button from "../ui/button/Button";
 import Input from "../form/input/InputField";
 import Label from "../form/Label";
 import useUserProfile from "@/hooks/useUserProfile";
+import { useAuth } from "@/context/AuthContext";
+import { doc, updateDoc } from "firebase/firestore";
+import { db } from "@/firebase";
 
 export default function UserInfoCard() {
   const { isOpen, openModal, closeModal } = useModal();
   const profile = useUserProfile();
-  const handleSave = () => {
-    // Handle save logic here
-    console.log("Saving changes...");
+  const { user } = useAuth();
+
+  const handleSave = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    if (!user) return;
+    const formData = new FormData(e.currentTarget);
+    const data = Object.fromEntries(formData.entries());
+    await updateDoc(doc(db, "users", user.uid), data, { merge: true });
     closeModal();
   };
   return (
@@ -104,7 +112,7 @@ export default function UserInfoCard() {
               Update your details to keep your profile up-to-date.
             </p>
           </div>
-          <form className="flex flex-col">
+          <form className="flex flex-col" onSubmit={handleSave}>
             <div className="custom-scrollbar h-[450px] overflow-y-auto px-2 pb-3">
               <div>
                 <h5 className="mb-5 text-lg font-medium text-gray-800 dark:text-white/90 lg:mb-6">
@@ -116,19 +124,21 @@ export default function UserInfoCard() {
                     <Label>Facebook</Label>
                     <Input
                       type="text"
+                      name="facebook"
                       defaultValue="https://www.facebook.com/PimjoHQ"
                     />
                   </div>
 
                   <div>
                     <Label>X.com</Label>
-                    <Input type="text" defaultValue="https://x.com/PimjoHQ" />
+                    <Input type="text" name="twitter" defaultValue="https://x.com/PimjoHQ" />
                   </div>
 
                   <div>
                     <Label>Linkedin</Label>
                     <Input
                       type="text"
+                      name="linkedin"
                       defaultValue="https://www.linkedin.com/company/pimjo"
                     />
                   </div>
@@ -137,6 +147,7 @@ export default function UserInfoCard() {
                     <Label>Instagram</Label>
                     <Input
                       type="text"
+                      name="instagram"
                       defaultValue="https://instagram.com/PimjoHQ"
                     />
                   </div>
@@ -150,27 +161,27 @@ export default function UserInfoCard() {
                 <div className="grid grid-cols-1 gap-x-6 gap-y-5 lg:grid-cols-2">
                   <div className="col-span-2 lg:col-span-1">
                     <Label>First Name</Label>
-                    <Input type="text" defaultValue={profile?.firstName ?? ""} />
+                    <Input name="firstName" type="text" defaultValue={profile?.firstName ?? ""} />
                   </div>
 
                   <div className="col-span-2 lg:col-span-1">
                     <Label>Last Name</Label>
-                    <Input type="text" defaultValue={profile?.lastName ?? ""} />
+                    <Input name="lastName" type="text" defaultValue={profile?.lastName ?? ""} />
                   </div>
 
                   <div className="col-span-2 lg:col-span-1">
                     <Label>Email Address</Label>
-                    <Input type="text" defaultValue={profile?.email ?? ""} />
+                    <Input name="email" type="text" defaultValue={profile?.email ?? ""} />
                   </div>
 
                   <div className="col-span-2 lg:col-span-1">
                     <Label>Phone</Label>
-                    <Input type="text" defaultValue={profile?.phone ?? ""} />
+                    <Input name="phone" type="text" defaultValue={profile?.phone ?? ""} />
                   </div>
 
                   <div className="col-span-2">
                     <Label>Bio</Label>
-                    <Input type="text" defaultValue={profile?.bio ?? ""} />
+                    <Input name="bio" type="text" defaultValue={profile?.bio ?? ""} />
                   </div>
                 </div>
               </div>
@@ -179,7 +190,7 @@ export default function UserInfoCard() {
               <Button size="sm" variant="outline" onClick={closeModal}>
                 Close
               </Button>
-              <Button size="sm" onClick={handleSave}>
+              <Button size="sm" type="submit">
                 Save Changes
               </Button>
             </div>

--- a/src/components/user-profile/UserMetaCard.tsx
+++ b/src/components/user-profile/UserMetaCard.tsx
@@ -7,14 +7,21 @@ import Input from "../form/input/InputField";
 import Label from "../form/Label";
 import Image from "next/image";
 import useUserProfile from "@/hooks/useUserProfile";
+import { useAuth } from "@/context/AuthContext";
+import { doc, updateDoc } from "firebase/firestore";
+import { db } from "@/firebase";
 
 
 export default function UserMetaCard() {
   const { isOpen, openModal, closeModal } = useModal();
   const profile = useUserProfile();
-  const handleSave = () => {
-    // Handle save logic here
-    console.log("Saving changes...");
+  const { user } = useAuth();
+  const handleSave = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    if (!user) return;
+    const formData = new FormData(e.currentTarget);
+    const data = Object.fromEntries(formData.entries());
+    await updateDoc(doc(db, "users", user.uid), data, { merge: true });
     closeModal();
   };
   return (
@@ -150,7 +157,7 @@ export default function UserMetaCard() {
               Update your details to keep your profile up-to-date.
             </p>
           </div>
-          <form className="flex flex-col">
+          <form className="flex flex-col" onSubmit={handleSave}>
             <div className="custom-scrollbar h-[450px] overflow-y-auto px-2 pb-3">
               <div>
                 <h5 className="mb-5 text-lg font-medium text-gray-800 dark:text-white/90 lg:mb-6">
@@ -162,19 +169,21 @@ export default function UserMetaCard() {
                     <Label>Facebook</Label>
                     <Input
                       type="text"
+                      name="facebook"
                       defaultValue="https://www.facebook.com/PimjoHQ"
                     />
                   </div>
 
                   <div>
                     <Label>X.com</Label>
-                    <Input type="text" defaultValue="https://x.com/PimjoHQ" />
+                    <Input type="text" name="twitter" defaultValue="https://x.com/PimjoHQ" />
                   </div>
 
                   <div>
                     <Label>Linkedin</Label>
                     <Input
                       type="text"
+                      name="linkedin"
                       defaultValue="https://www.linkedin.com/company/pimjo"
                     />
                   </div>
@@ -183,6 +192,7 @@ export default function UserMetaCard() {
                     <Label>Instagram</Label>
                     <Input
                       type="text"
+                      name="instagram"
                       defaultValue="https://instagram.com/PimjoHQ"
                     />
                   </div>
@@ -196,27 +206,32 @@ export default function UserMetaCard() {
                 <div className="grid grid-cols-1 gap-x-6 gap-y-5 lg:grid-cols-2">
                   <div className="col-span-2 lg:col-span-1">
                     <Label>First Name</Label>
-                    <Input type="text" defaultValue={profile?.firstName ?? ""} />
+                    <Input name="firstName" type="text" defaultValue={profile?.firstName ?? ""} />
                   </div>
 
                   <div className="col-span-2 lg:col-span-1">
                     <Label>Last Name</Label>
-                    <Input type="text" defaultValue={profile?.lastName ?? ""} />
+                    <Input name="lastName" type="text" defaultValue={profile?.lastName ?? ""} />
                   </div>
 
                   <div className="col-span-2 lg:col-span-1">
                     <Label>Email Address</Label>
-                    <Input type="text" defaultValue={profile?.email ?? ""} />
+                    <Input name="email" type="text" defaultValue={profile?.email ?? ""} />
+                  </div>
+
+                  <div className="col-span-2 lg:col-span-1">
+                    <Label>Photo URL</Label>
+                    <Input name="photoURL" type="text" defaultValue={profile?.photoURL ?? ""} />
                   </div>
 
                   <div className="col-span-2 lg:col-span-1">
                     <Label>Phone</Label>
-                    <Input type="text" defaultValue={profile?.phone ?? ""} />
+                    <Input name="phone" type="text" defaultValue={profile?.phone ?? ""} />
                   </div>
 
                   <div className="col-span-2">
                     <Label>Bio</Label>
-                    <Input type="text" defaultValue={profile?.bio ?? ""} />
+                    <Input name="bio" type="text" defaultValue={profile?.bio ?? ""} />
                   </div>
                 </div>
               </div>
@@ -225,7 +240,7 @@ export default function UserMetaCard() {
               <Button size="sm" variant="outline" onClick={closeModal}>
                 Close
               </Button>
-              <Button size="sm" onClick={handleSave}>
+              <Button size="sm" type="submit">
                 Save Changes
               </Button>
             </div>

--- a/src/hooks/useUserProfile.ts
+++ b/src/hooks/useUserProfile.ts
@@ -1,6 +1,6 @@
 "use client";
 import { useEffect, useState } from "react";
-import { doc, getDoc } from "firebase/firestore";
+import { doc, getDoc, setDoc } from "firebase/firestore";
 import { db } from "@/firebase";
 import { useAuth } from "@/context/AuthContext";
 
@@ -28,7 +28,16 @@ export default function useUserProfile() {
         const snap = await getDoc(ref);
         if (snap.exists()) {
           setProfile(snap.data() as UserProfile);
+        } else {
+          const data: UserProfile = {
+            email: user.email ?? "",
+            photoURL: user.photoURL ?? "",
+          };
+          await setDoc(ref, data);
+          setProfile(data);
         }
+      } else {
+        setProfile(null);
       }
     }
     load();


### PR DESCRIPTION
## Summary
- create missing user profile on first load
- update user info and meta cards to store changes in Firestore
- display photo URL field on user meta card
- fetch and list Firestore users in management table

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68771931884c8326b950269de630790c