### PR TITLE
Fix BasicTableOne build error

### DIFF
--- a/src/components/tables/BasicTableOne.tsx
+++ b/src/components/tables/BasicTableOne.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import React, { useEffect, useState } from "react";
 import {
   Table,


### PR DESCRIPTION
## Summary
- mark `BasicTableOne` as a client component so hooks work

## Testing
- `npm run lint`
- `npm run build` *(fails: failed to fetch font because internet is disabled)*

------
https://chatgpt.com/codex/tasks/task_e_687779d8d6708326822cdccfd575e82f